### PR TITLE
Refactor: remove unnecessary padding and margin in manager dashboard CSS

### DIFF
--- a/static/css/manager-dashboard.css
+++ b/static/css/manager-dashboard.css
@@ -481,7 +481,6 @@ body {
 
 .form-section {
     margin-bottom: 2.5rem;
-    padding-bottom: 2rem;
     border-bottom: 1px solid var(--border-color);
 }
 
@@ -503,7 +502,6 @@ body {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1.75rem;
-    margin-bottom: 1.75rem;
 }
 
 .form-group {


### PR DESCRIPTION
This pull request includes minor changes to the `static/css/manager-dashboard.css` file, specifically within the `body` section. The changes involve adjustments to the margins and padding of certain elements.

Changes in `static/css/manager-dashboard.css`:

* Removed the bottom padding from the `.form-section` class.
* Removed the bottom margin from the grid display section.

Before:

![image](https://github.com/user-attachments/assets/3f919c03-8eef-446a-a748-da9c08d05853)

After:

![image](https://github.com/user-attachments/assets/1d816126-872e-4ae0-8807-aa79b83f8880)

## Summary by Sourcery

Removes unnecessary padding and margin from the manager dashboard CSS to improve visual appearance.

Enhancements:
- Removes bottom padding from the `.form-section` class.
- Removes bottom margin from the grid display section.